### PR TITLE
Support iPad

### DIFF
--- a/Sources/TickerView/TickerView.swift
+++ b/Sources/TickerView/TickerView.swift
@@ -62,7 +62,12 @@ public final class TickerView: UIView {
         super.init(coder: coder)
         configureScrollView()
     }
-    
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        updateScrollViewFrame()
+    }
+
     /// Sets the text to be displayed in the scrolling animation view.
     /// - Parameter text: The text to be displayed in the animation view.
     public func setText(_ text: String) {
@@ -96,7 +101,12 @@ public final class TickerView: UIView {
         scrollView.addSubview(label)
         addSubview(scrollView)
     }
-    
+
+    private func updateScrollViewFrame() {
+        scrollView.frame = bounds
+        scrollView.contentSize = CGSize(width: frame.size.width, height: frame.size.height)
+    }
+
     private func resetLabelFrame() {
         label.frame.origin.x = frame.size.width
     }


### PR DESCRIPTION
## About

In the case of iPad, view returns the following `bounds` at the time of `TickerView.init()`, and the scrolling area of TickerView is not allocated in the correct size.
So we fixed it so that the ScrollView size is updated when `layoutSubviews()` is called.

With this fix, the iPad's SplitView is now supported.

```
(lldb) po bounds
▿ (0.0, 0.0, 361.0, 44.0)
  ▿ origin : (0.0, 0.0)
    - x : 0.0
    - y : 0.0
  ▿ size : (361.0, 44.0)
    - width : 361.0
    - height : 44.0
```

| Gif on iPad | After |
| :-: | :-: |
| ![Simulator Screen Recording - iPad Air 13-inch (M2) - 2024-07-25 at 14 30 40](https://github.com/user-attachments/assets/cd11ca71-47da-4e7e-85aa-984d5fe99895) | ![Simulator Screen Recording - iPad Air 13-inch (M2) - 2024-07-25 at 14 34 56](https://github.com/user-attachments/assets/b5e5d2fd-1342-4464-91bc-1e25b904e9ef) |

<details><summary>Japanese</summary><div>

## 内容

iPad の場合 `TickerView.init()` の時点では以下のような `bounds` が流れてきてしまい、正しいサイズで `TickerView` のスクロール領域が確保されない状態になっていたため、`layoutSubviews()` が呼ばれた時点で ScrollView のサイズを更新するように修正しました。

この修正により iPad の SplitView にも対応できる状態になると思います。

```
(lldb) po bounds
▿ (0.0, 0.0, 361.0, 44.0)
  ▿ origin : (0.0, 0.0)
    - x : 0.0
    - y : 0.0
  ▿ size : (361.0, 44.0)
    - width : 361.0
    - height : 44.0
```

</div></details>